### PR TITLE
Improv

### DIFF
--- a/dnscrypt-proxy-aarch64.yml
+++ b/dnscrypt-proxy-aarch64.yml
@@ -1,8 +1,5 @@
 kernel:
-  # image: linuxkit/kernel:4.14.34
-  # Use a 4.9.x kernel on RPi3 as the serial is different/
-  # currently broken with 4.14: https://github.com/linuxkit/linuxkit/issues/3008
-  image: linuxkit/kernel:4.9.89
+  image: linuxkit/kernel:4.14.38
   cmdline: "console=tty0 console=ttyAMA0"
 init:
   - linuxkit/init:v0.3

--- a/dnscrypt-proxy-aarch64.yml
+++ b/dnscrypt-proxy-aarch64.yml
@@ -12,6 +12,9 @@ onboot:
   - name: netdev
     image: linuxkit/modprobe:v0.3
     command: ["modprobe", "smsc95xx"]
+  - name: usbstorage
+    image: linuxkit/modprobe:v0.3
+    command: ["modprobe", "usb_storage"]
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.3
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]

--- a/dnscrypt-proxy-aarch64.yml
+++ b/dnscrypt-proxy-aarch64.yml
@@ -18,6 +18,18 @@ onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.3
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
+  - name: ntp-oneshot
+    # Use the busybox 'ntpd' to force set the time.
+    image: library/alpine:3.7
+    command: ["ntpd", "-d", "-n", "-q", "-p", "pool.ntp.org"]
+    capabilities:
+      - CAP_SYS_TIME
+      - CAP_SYS_NICE
+      - CAP_SYS_CHROOT
+      - CAP_SETUID
+      - CAP_SETGID
+    binds:
+      - /etc/resolv.conf:/etc/resolv.conf
 services:
   - name: getty
     image: linuxkit/getty:v0.3

--- a/dnscrypt-proxy-x86_64.yml
+++ b/dnscrypt-proxy-x86_64.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.37
+  image: linuxkit/kernel:4.14.38
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:v0.3

--- a/dnscrypt-proxy-x86_64.yml
+++ b/dnscrypt-proxy-x86_64.yml
@@ -15,6 +15,18 @@ onboot:
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.3
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
+  - name: ntp-oneshot
+    # Use the busybox 'ntpd' to force set the time.
+    image: library/alpine:3.7
+    command: ["ntpd", "-d", "-n", "-q", "-p", "pool.ntp.org"]
+    capabilities:
+      - CAP_SYS_TIME
+      - CAP_SYS_NICE
+      - CAP_SYS_CHROOT
+      - CAP_SETUID
+      - CAP_SETGID
+    binds:
+      - /etc/resolv.conf:/etc/resolv.conf
 services:
   - name: getty
     image: linuxkit/getty:v0.3

--- a/dnscrypt-proxy-x86_64.yml
+++ b/dnscrypt-proxy-x86_64.yml
@@ -9,6 +9,9 @@ init:
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:v0.3
+  - name: usbstorage
+    image: linuxkit/modprobe:v0.3
+    command: ["modprobe", "usb_storage"]
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.3
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]


### PR DESCRIPTION
- switch arm64 kernel to 4.14 again
- load `usb_storage`
- Add a one shot NTP to onboot.

The last bit makes dnscrypt work again as now the time is set correctly and the certs used by dnscrypt to get the initial list of servers can be validated (they did not work in 1.1.1970)